### PR TITLE
generic expression aggregation check all children are -> any child is

### DIFF
--- a/dj/sql/parsing/ast.py
+++ b/dj/sql/parsing/ast.py
@@ -553,7 +553,7 @@ class Expression(Node):
         """
         Determines whether an Expression is an aggregation or not
         """
-        return all(
+        return any(
             [
                 child.is_aggregation()
                 for child in self.children


### PR DESCRIPTION
### Summary

changes the generic logic checking if an expression is an aggregation to just checking if there is any child which aggregates rather than all children aggregating

this would be a problem because of the binop default `is_aggregation`:

```sh
curl -X POST http://localhost:8000/nodes/metric/ \
-H 'Content-Type: application/json' \
-d '{
    "name": "num_repair_orders_x_2",
    "description": "Number of repair orders",
    "mode": "published",
    "query": "SELECT 2.0 * count(repair_order_id) as num_repair_orders FROM repair_orders"
}'
```

which would succeed after this change. Now, `2.0 * count(repair_order_id)` is identified as an aggregation

### Test Plan

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage
